### PR TITLE
Only remove the passed callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var EmitOnOff = module.exports = function(thing){
     if (!thing._subs[name]) return;
     for (var i in thing._subs[name]){
       if (thing._subs[name][i] === cb){
-        thing._subs[name].splice(i);
+        thing._subs[name].splice(i, 1);
         break;
       }
     }


### PR DESCRIPTION
Right now, it removes callbacks from `i` through the end of the array.

> **If deleteCount is omitted**, or if its value is larger than array.length - start, then all of the elements beginning with start index on **through the end of the array will be deleted.**

[Array.prototype.splice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)